### PR TITLE
Improve help text for 'sitediff init --output'.

### DIFF
--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -140,7 +140,7 @@ class SiteDiff
     option :output,
       :type => :string,
       :default => 'sitediff',
-      :desc => 'Where to place the configuration',
+      :desc => 'Directory in which to place the configuration',
       :aliases => ['-o']
     option :depth,
       :type => :numeric,


### PR DESCRIPTION
Makes help text for the `sitediff init` `--output` parameter.