### PR TITLE
Code-breaking bug fix.

### DIFF
--- a/lib/sitediff/webserver/resultserver.rb
+++ b/lib/sitediff/webserver/resultserver.rb
@@ -13,7 +13,7 @@ class SiteDiff
           @cache = cache
         end
 
-        def do_get(req, res)
+        def do_GET(req, res)
           path = req.path_info
           (md = %r{^/([^/]+)(/.*)$}.match(path)) ||
             raise(WEBrick::HTTPStatus::NotFound)
@@ -44,7 +44,7 @@ class SiteDiff
           end
         end
 
-        def do_get(req, res)
+        def do_GET(req, res)
           path = req.path_info
           before, after = *urls(path)
 


### PR DESCRIPTION
…r ran, because the purpose of "do_GET" was to overwrite the parent Ruby class's method.

The consequences of this were that all the non-trivial links served by "sitediff serve" were broken.