### PR TITLE
Modify Dockerfile to work with required version of Ruby

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.bundle/
+vendor/
+Gemfile.lock
+sitediff
+.idea
+.vscode
+Dockerfile
+Dockerfile-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,5 @@ RUN gem build sitediff.gemspec && gem install sitediff --no-rdoc --no-ri
 
 # Build locally
 RUN bundle install
+
+ENTRYPOINT [ "sitediff "]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y python-software-properties software-properties-common
 
+# We want a more recent ruby:
+RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get update
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -8,7 +12,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Nokogiri requires libxml2, libxslt, pkg-config to build
 # Typhoeus requires libcurl3 to run
 # We need rake for our build
-RUN apt-get install -y ruby-dev make pkg-config libxml2-dev libxslt-dev libcurl3 bundler
+RUN apt-get install -y ruby2.5 ruby2.5-dev curl make pkg-config libxml2-dev libxslt-dev libcurl3 bundler
 
 # Force nokogiri gem not to compile libxml2, it takes too long
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -13,3 +13,5 @@ RUN gem build sitediff.gemspec && gem install sitediff --no-rdoc --no-ri
 
 # Build locally
 RUN bundle install
+
+ENTRYPOINT [ "sitediff" ]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,3 +1,11 @@
+# An Alpine-based Dockerfile for the sitediff utility
+# http://evolvingweb.github.io/sitediff
+#
+# It's easier and quicker to produce a container based on Alpine Linux,
+# and the resulting image files are much smaller.
+# 
+# Quentin Stafford-Fraser 2018
+#
 FROM alpine
 RUN apk update
 RUN apk add ruby ruby-dev make libxml2-dev libxslt-dev build-base

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,15 @@
+FROM alpine
+RUN apk update
+RUN apk add ruby ruby-dev make libxml2-dev libxslt-dev build-base
+RUN apk add ruby-bundler libcurl ruby-webrick
+RUN apk add gdbm ruby-dbm
+RUN gem install thor rspec --no-rdoc --no-ri
+
+ADD . /sitediff
+WORKDIR /sitediff
+
+# Build as a gem
+RUN gem build sitediff.gemspec && gem install sitediff --no-rdoc --no-ri
+
+# Build locally
+RUN bundle install

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,24 @@
+# Running sitediff under Docker
+
+Using Docker to run sitediff can be easier than getting the appropriate environment set up, with the right versions of Ruby etc, on your machine.
+
+There are two Dockerfiles here: one is based on Ubuntu and one on Alpine Linux, which is quicker to build and produces much smaller container images.
+
+Suppose you decide to use the Alpine one.  Build a container with 
+
+    docker build -t sitediff -f Dockerfile-alpine .
+
+then you can run it, at its most basic, with:
+
+    docker run sitediff
+
+However, in reality, you probably want it to be able to output some files into, say, the current directory, so you could mount that in the container as /sitediff using a `-v` option. 
+
+And you want to see output as it is produced, in pretty colours, so you might tell it you have a more intereactive terminal using a `-it` option.
+
+So your typical first command might look more like:
+
+    docker run -it -v `pwd`:/sitediff sitediff http://mysite.com
+
+
+*Quentin Stafford-Fraser, Dec 2018*

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -18,12 +18,33 @@ And you want to see output as it is produced, in pretty colours, so you might te
 
 So your typical first command might look more like:
 
-    docker run -it -v `pwd`:/sitediff sitediff http://mysite.com
+    docker run -it -v `pwd`:/sitediff sitediff init http://mysite.com
 
 If you wish to make use of sitediff's ability to serve up its own web pages with the 'serve' command, you'll also need to enable access to the port it uses to do that, normally 13080, e.g.
 
     docker run -it -v `pwd`:/sitediff -p 13080:13080 sitediff serve
 
 and then connect to http://localhost:13080.
+
+Lastly, if the website you want to compare is running on your Docker host machine, 
+as it may well be during development, then remember you can use the special hostname
+'host.docker.internal' to refer to the host from within a container.
+
+So, imagine you want to compare the public site http://mysite.com to the version running on port 80 on your laptop. You might do something like this:
+
+    # Create a local configuration and cache of the public site
+    # in the mysite directory, with the local copy as the 'after' version:
+
+    docker run -it -p 13080:13080 -v `pwd`/mysite:/sitediff \
+        sitediff init \
+        http://mysite.com \
+        http://host.docker.internal
+
+    # Now compare the two, but use the original URLs in the report:
+    docker run -it -v `pwd`/mysite:/sitediff sitediff diff \
+        --after-url-report=http://localhost
+
+    # Now serve up comparison on localhost:13080
+    docker run -it -v `pwd`/mysite:/sitediff sitediff serve
 
 *Quentin Stafford-Fraser, Dec 2018*

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -20,5 +20,10 @@ So your typical first command might look more like:
 
     docker run -it -v `pwd`:/sitediff sitediff http://mysite.com
 
+If you wish to make use of sitediff's ability to serve up its own web pages with the 'serve' command, you'll also need to enable access to the port it uses to do that, normally 13080, e.g.
+
+    docker run -it -v `pwd`:/sitediff -p 13080:13080 sitediff serve
+
+and then connect to http://localhost:13080.
 
 *Quentin Stafford-Fraser, Dec 2018*


### PR DESCRIPTION
The current Dockerfile wouldn't work for me because sitediff wanted a newer version of ruby.

I don't know enough about Ruby to know the best way to do this. My solution was to update ubuntu to 16.04, add a new debian repository source, and get ruby2.5 from there.  

There's probably a much more 'official' solution, so do feel free to discard this PR; I offer it only as a 'something like this is needed to make it work' comment!

Now running on my Mac - thanks!
