### PR TITLE
Fixes and features for v4 release

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 15
 Metrics/AbcSize:
-  Max: 66
+  Max: 66.07
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SiteDiff
 
-**Note:** Please note that version 0.1.0 introduces many backwards incompatible changes.
+**Note:** Please note that version 0.0.4 introduces many backwards incompatible changes.
 
 [![Build Status](https://travis-ci.org/evolvingweb/sitediff.svg?branch=master)](https://travis-ci.org/evolvingweb/sitediff)
 [![CircleCI Status](https://circleci.com/gh/evolvingweb/sitediff/tree/master.png?style=shield)](https://circleci.com/gh/evolvingweb/sitediff)

--- a/README.md
+++ b/README.md
@@ -133,13 +133,11 @@ To get help on the options for a particular command, eg: ```diff```:
 
 * **Finding configuration files**
 
-  SiteDiff will attempt to auto-detect any nearby ```sitediff.yaml``` files. But if your ```sitediff.yaml``` is in an unusual place, you can force SiteDiff to change to that directory:
+  By default SiteDiff will put everything in the `sitediff` folder. You can use the `--directory` flag to specify a different directory.
 
-  ```sitediff diff -C some-directory```
-
-  Or you can even specify a list of config files at the command-line:
-
-  ```sitediff diff myconfig.yaml otherconfig.yaml ...```
+  ```sitediff init -C my_project_folder https://example.com
+  sitediff diff -C my_project_folder
+  sitediff serve -C my_project_folder```
 
 * **Handling large configuration files**
 
@@ -183,21 +181,28 @@ To get help on the options for a particular command, eg: ```diff```:
 
   ```sitediff diff --after-url-report=http://vagrant:8080```
 
+* **Curl options**
+
+  [Many options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html) can be passed to the underlying curl library. Add `--curl_options=name1:value1 name2:value2` to the command line (such as `--curl_options=max_recv_speed_large:100000 ssl_verifypeer:false` (remove the `CURLOPT_` prefix and write the name in lowercase) or add them to your configuration file.
+
+  ```yaml
+  curl_opts:
+    max_recv_speed_large: 10000
+    ssl_verifypeer: false
+  ```
+
+  The command line options overwrite what is in the `settings.yaml` file.
+
 * **Throttling**
 
   A few options are available if you want to control how aggressive SiteDiff crawls.
 
      - There's a command line option `--concurrency=N` for both `sitediff init` and `sitediff diff` which controls the maximum number of simultaneous connections made. Lower N mean less aggressive. The default is 3.
-     - The underlying curl library has [many options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html) such as `max_recv_speed_large`. Just add them to your configuration file.
-
-  ```yaml
-  curl_opts:
-    max_recv_speed_large: 10000
-  ```
+     - The underlying curl library has [many options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html) such as `max_recv_speed_large` which can be helpful.
 
 * **Timeouts**
 
-  By default, no timeout is set but one can be added in your configuration file.
+  By default, no timeout is set but one can be added `--curl_options=timeout:60` or in your configuration file.
 
   ```yaml
   curl_opts:
@@ -210,6 +215,7 @@ To get help on the options for a particular command, eg: ```diff```:
   curl_opts:
     timeout_ms: 60000
   ```
+
 ## Configuration
 
 SiteDiff relies on a [YAML](http://yaml.org/) configuration file, usually called ```sitediff.yaml```. You can create a reasonable one using ```sitediff init```, but there are many useful things you may want to manually add or change.

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -100,7 +100,7 @@ class SiteDiff
 
   # Perform the comparison, populate @results and return the number of failing
   # paths (paths with non-zero diff).
-  def run
+  def run(curl_opts = {})
     # Map of path -> Result object, populated by process_results
     @results = {}
     @ordered = @config.paths.dup
@@ -113,7 +113,8 @@ class SiteDiff
     # TODO: Fix this after config merge refactor!
     # Not quite right. We are not passing @config.before or @config.after
     # so passing this instead but @config.after['curl_opts'] is ignored.
-    curl_opts = @config.before['curl_opts']
+    config_curl_opts = @config.before['curl_opts']
+    curl_opts = config_curl_opts.clone.merge(curl_opts) if config_curl_opts
     fetcher = Fetch.new(@cache, @config.paths, @concurrency, curl_opts,
                         before: before, after: after)
     fetcher.run(&method(:process_results))

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -150,7 +150,7 @@ class SiteDiff
 
     # serve some settings
     settings = { 'before' => report_before, 'after' => report_after,
-                 'cached' => @cache.read_tags.map(&:to_s) }
+                 'cached' => %w[before after] }
     dir.+(SETTINGS_FILE).open('w') { |f| YAML.dump(settings, f) }
   end
 end

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -25,6 +25,9 @@ class SiteDiff
       filename = File.join(@dir, 'snapshot', tag.to_s, *path.split(File::SEPARATOR))
 
       filename = File.join(filename, 'index.html') if File.directory?(filename)
+      if !File.file? filename
+        return nil
+      end
       Marshal.load(File.read(filename))
     end
 

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -25,9 +25,8 @@ class SiteDiff
       filename = File.join(@dir, 'snapshot', tag.to_s, *path.split(File::SEPARATOR))
 
       filename = File.join(filename, 'index.html') if File.directory?(filename)
-      if !File.file? filename
-        return nil
-      end
+      return nil unless File.file? filename
+
       Marshal.load(File.read(filename))
     end
 

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -156,6 +156,10 @@ class SiteDiff
            type: :hash,
            default: {},
            desc: 'Options to be passed to curl'
+    option :insecure,
+           type: :boolean,
+           default: false,
+           desc: 'Ignore many HTTPS/SSL errors'
     desc 'init URL [URL]', 'Create a sitediff configuration'
     def init(*urls)
       unless (1..2).cover? urls.size
@@ -164,7 +168,11 @@ class SiteDiff
       end
 
       curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
-      # Need to be able to add curl options there!
+      if options[:insecure]
+        curl_opts[:ssl_verifypeer] = false
+        curl_opts[:ssl_verifyhost] = 0
+      end
+
       creator = SiteDiff::Config::Creator.new(options[:concurrency], curl_opts, *urls)
       creator.create(
         depth: options[:depth],

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -206,17 +206,19 @@ class SiteDiff
         SiteDiff.log "Visited #{path}, cached"
       end
     end
-  end
 
-  def get_curl_opts(options)
-    # We do want string keys here
-    bool_hash = { 'true' => true, 'false' => false }
-    curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
-    curl_opts.each { |k, v| curl_opts[k] = bool_hash.fetch(v, v) }
-    if options[:insecure]
-      curl_opts[:ssl_verifypeer] = false
-      curl_opts[:ssl_verifyhost] = 0
+    no_commands do
+      def get_curl_opts(options)
+        # We do want string keys here
+        bool_hash = { 'true' => true, 'false' => false }
+        curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
+        curl_opts.each { |k, v| curl_opts[k] = bool_hash.fetch(v, v) }
+        if options[:insecure]
+          curl_opts[:ssl_verifypeer] = false
+          curl_opts[:ssl_verifyhost] = 0
+        end
+        curl_opts
+      end
     end
-    curl_opts
   end
 end

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -152,6 +152,10 @@ class SiteDiff
            type: :numeric,
            default: 3,
            desc: 'Max number of concurrent connections made'
+    option :curl_options,
+           type: :hash,
+           default: {},
+           desc: 'Options to be passed to curl'
     desc 'init URL [URL]', 'Create a sitediff configuration'
     def init(*urls)
       unless (1..2).cover? urls.size
@@ -159,8 +163,9 @@ class SiteDiff
         exit 2
       end
 
+      curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
       # Need to be able to add curl options there!
-      creator = SiteDiff::Config::Creator.new(options[:concurrency], UriWrapper::DEFAULT_CURL_OPTS, *urls)
+      creator = SiteDiff::Config::Creator.new(options[:concurrency], curl_opts, *urls)
       creator.create(
         depth: options[:depth],
         directory: options[:directory],

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -34,18 +34,6 @@ class SiteDiff
       true
     end
 
-    def get_curl_opts(options)
-      # We do want string keys here
-      bool_hash = { 'true' => true, 'false' => false }
-      curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
-      curl_opts.each { |k, v| curl_opts[k] = bool_hash.fetch(v, v) }
-      if options[:insecure]
-        curl_opts[:ssl_verifypeer] = false
-        curl_opts[:ssl_verifyhost] = 0
-      end
-      curl_opts
-    end
-
     option 'paths-file',
            type: :string,
            desc: 'Paths are read (one at a line) from PATHS: ' \
@@ -218,5 +206,17 @@ class SiteDiff
         SiteDiff.log "Visited #{path}, cached"
       end
     end
+  end
+
+  def get_curl_opts(options)
+    # We do want string keys here
+    bool_hash = { 'true' => true, 'false' => false }
+    curl_opts = UriWrapper::DEFAULT_CURL_OPTS.clone.merge(options[:curl_options])
+    curl_opts.each { |k, v| curl_opts[k] = bool_hash.fetch(v, v) }
+    if options[:insecure]
+      curl_opts[:ssl_verifypeer] = false
+      curl_opts[:ssl_verifyhost] = 0
+    end
+    curl_opts
   end
 end

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -94,11 +94,9 @@ class SiteDiff
         # If single-site, cache after as before!
         @cache.set(:before, path, res) unless roots[:before]
 
-        # Not sure why we'd ever want to apply sanitization at download time
-        # Maybe it was back when we wanted to cache the modified version.
-        # The line below was added on Tue Apr 28 18:11:58 2015 -0400
-        # (ignore the "reformat" commit) I suspect semantics have changed since.
-        @rules.handle_page(tag, res.content, info.document) if @rules && !res.error && !@rules.disabled
+        # This is used to populate the list of rules we guess are
+        # applicable to the current site.
+        @rules.handle_page(tag, res.content, info.document) if @rules && !res.error
       end
 
       # Create a gitignore if we seem to be in git

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -64,7 +64,7 @@ class SiteDiff
       def crawl(depth = nil)
         hydra = Typhoeus::Hydra.new(max_concurrency: @concurrency)
         roots.each do |tag, u|
-          Crawler.new(hydra, u, depth) do |info|
+          Crawler.new(hydra, u, depth, @curl_opts) do |info|
             crawled_path(tag, info)
           end
         end

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -94,7 +94,11 @@ class SiteDiff
         # If single-site, cache after as before!
         @cache.set(:before, path, res) unless roots[:before]
 
-        @rules.handle_page(tag, res.content, info.document) if @rules && !res.error
+        # Not sure why we'd ever want to apply sanitization at download time
+        # Maybe it was back when we wanted to cache the modified version.
+        # The line below was added on Tue Apr 28 18:11:58 2015 -0400
+        # (ignore the "reformat" commit) I suspect semantics have changed since.
+        @rules.handle_page(tag, res.content, info.document) if @rules && !res.error && !@rules.disabled
       end
 
       # Create a gitignore if we seem to be in git

--- a/lib/sitediff/files/html_report.html.erb
+++ b/lib/sitediff/files/html_report.html.erb
@@ -21,6 +21,9 @@
                <a href="<%= eval(tag) %>"><%= eval(tag) %></a>
         <% end %>
       </div>
+      <div class="run">
+        <a href="../run/diff">Rerun diff</a>
+      </div>
       <table class="results">
 
         <colgroup>

--- a/lib/sitediff/rules.rb
+++ b/lib/sitediff/rules.rb
@@ -14,6 +14,8 @@ class SiteDiff
       @rules = Hash.new { |h, k| h[k] = Set.new }
     end
 
+    attr_reader :disabled
+
     def find_sanitization_candidates
       @candidates = Set.new
 

--- a/lib/sitediff/rules.rb
+++ b/lib/sitediff/rules.rb
@@ -14,8 +14,6 @@ class SiteDiff
       @rules = Hash.new { |h, k| h[k] = Set.new }
     end
 
-    attr_reader :disabled
-
     def find_sanitization_candidates
       @candidates = Set.new
 

--- a/lib/sitediff/uriwrapper.rb
+++ b/lib/sitediff/uriwrapper.rb
@@ -108,9 +108,17 @@ class SiteDiff
       end
 
       req.on_failure do |resp|
-        msg = 'Unknown Error'
-        msg = resp.status_message if resp&.status_message
-        yield ReadResult.error("HTTP error #{@uri}: #{msg}", resp.response_code)
+        if resp&.status_message
+          msg = resp.status_message
+          yield ReadResult.error("HTTP error when loading #{@uri}: #{msg}",
+                                 resp.response_code)
+        elsif (msg = resp.options[:return_code])
+          yield ReadResult.error("Connection error when loading #{@uri}: #{msg}",
+                                 resp.response_code)
+        else
+          yield ReadResult.error("Unknown error when loading #{@uri}: #{msg}",
+                                 resp.response_code)
+        end
       end
 
       req

--- a/lib/sitediff/webserver/resultserver.rb
+++ b/lib/sitediff/webserver/resultserver.rb
@@ -54,6 +54,34 @@ class SiteDiff
         end
       end
 
+      # Run sitediff command from browser. Probably dangerous in general.
+      class RunServlet < WEBrick::HTTPServlet::AbstractServlet
+        def initialize(_server, dir)
+          @dir = dir
+        end
+
+        def do_GET(req, res)
+          path = req.path_info
+          if path != '/diff'
+            res['content-type'] = 'text/plain'
+            res.body = 'ERROR: Only /run/diff is supported by the /run API at the moment'
+            return
+          end
+          # Thor assumes only one command is called and some values like
+          # `options` are share across all SiteDiff::Cli instances so
+          # we can't just call SiteDiff::Cli.new().diff
+          # This is likely to go very wrong depending on how `sitediff serve`
+          # was actually called
+          cmd = "#{$PROGRAM_NAME} diff -C #{@dir} --cached=all"
+          system(cmd)
+
+          # Could also add a message to indicate success/failure
+          # But for the moment, all our files are static
+          res.set_redirect(WEBrick::HTTPStatus::Found,
+                           "/files/#{SiteDiff::REPORT_FILE}")
+        end
+      end
+
       def initialize(port, dir, opts = {})
         unless File.exist?(File.join(dir, SiteDiff::SETTINGS_FILE))
           raise SiteDiffException,
@@ -81,6 +109,7 @@ class SiteDiff
         srv.mount('/files', WEBrick::HTTPServlet::FileHandler, dir, true)
         srv.mount('/cache', CacheServlet, @cache)
         srv.mount('/sidebyside', SideBySideServlet, @cache, @settings)
+        srv.mount('/run', RunServlet, dir)
         srv
       end
 


### PR DESCRIPTION
- Fixes side-by-side (i.e., [both]) view
- Add command-line curl options
- Add `--insecure` options to handle SSL errors
- Add error messages for connection errors
- ~Do not apply sanitization rules on `sitediff init` by default~ Undone