### PR TITLE
UTF8 and Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-- 2.5
+- 2.3
 # FIXME: jruby doesn't work. No idea about rbx.
 
 sudo: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install Ruby.
 RUN apt-get update
 RUN apt-get install -y software-properties-common 
-RUN add-apt-repository -y ppa:brightbox/ruby-ng
+#RUN add-apt-repository -y ppa:brightbox/ruby-ng
 RUN apt-get update
-RUN apt-get install -y ruby2.5 ruby2.5-dev make pkg-config libxml2-dev libxslt-dev libcurl3 bundler
+RUN apt-get install -y ruby2.3 ruby2.3-dev make pkg-config libxml2-dev libxslt-dev libcurl3 bundler
 
 # Force nokogiri gem not to compile libxml2, it takes too long
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'date', '1.0.0'
+  gem 'date'
   gem 'fileutils', '1.1.0'
   gem 'rspec'
   gem 'thor'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'date'
   gem 'fileutils', '1.1.0'
   gem 'rspec'
   gem 'thor'

--- a/lib/sitediff/sanitize.rb
+++ b/lib/sitediff/sanitize.rb
@@ -144,6 +144,10 @@ class SiteDiff
 
       # There's a lot of cruft left over,that we don't want
 
+      # Prevent potential UTF-8 encoding errors by removing invalid bytes.
+      # Not the only solution.
+      # An alternative is to return the string unmodified.
+      str = str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
       # Remove xml declaration and <html> tags
       str.sub!(/\A<\?xml.*$\n/, '')
       str.sub!(/\A^<html>$\n/, '')

--- a/lib/sitediff/sanitize/regexp.rb
+++ b/lib/sitediff/sanitize/regexp.rb
@@ -47,6 +47,10 @@ class SiteDiff
       def gsub!(str)
         re = ::Regexp.new(@rule['pattern'])
         sub = @rule['substitute'] || ''
+        # Prevent potential UTF-8 encoding errors by removing bytes
+        # Not the only solution. An alternative is to return the
+        # string unmodified.
+        str = str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
         str.gsub!(re, sub)
         str
       end


### PR DESCRIPTION
Fixing issues preventing the Bundle gem build form working in Ruby 2.3.
Porting the UTF-8 fix.