### PR TITLE
Redmine item #15168 - support for URL whitelist and blacklist

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,13 @@ AllCops:
 Style/MutableConstant:
   Exclude:
     - 'lib/sitediff/sanitize/dom_transform.rb'
+
+# Disable rule enforcing unreadable styles
+Style/Next:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,11 +58,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-<<<<<<< HEAD
-  Max: 6
-=======
   Max: 9
->>>>>>> 553a014... Redmine item #15168 - support for URL whitelist and blacklist
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 194
+  Max: 222
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:
@@ -58,7 +58,11 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
+<<<<<<< HEAD
   Max: 6
+=======
+  Max: 9
+>>>>>>> 553a014... Redmine item #15168 - support for URL whitelist and blacklist
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ To get help on the options for a particular command, eg: ```diff```:
     timeout_ms: 60000
   ```
 
+* **Whitelisting and Blacklisting**
+
+  By default sitediff crawls pages that are indicated with an HTML anchor using the `<A HREF` syntax. Most pages linked will be HTML pages, but some links will contain binaries such as PDF documents and images. 
+    - Using the option `--blacklist='.*\.pdf'` ensures the crawler skips links for document with a `.pdf` extension. Note that the regular expression is applied to the path of the URL, not the base of the URL. For example `--blacklist='.*.com'` will not match `http://www.google.com/.
+
+
 ## Configuration
 
 SiteDiff relies on a [YAML](http://yaml.org/) configuration file, usually called ```sitediff.yaml```. You can create a reasonable one using ```sitediff init```, but there are many useful things you may want to manually add or change.

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -11,8 +11,10 @@ require 'yaml'
 class SiteDiff
   class Config
     class Creator
-      def initialize(concurrency, curl_opts, debug, *urls)
+      def initialize(concurrency, whitelist, blacklist, curl_opts, debug, *urls)
         @concurrency = concurrency
+        @whitelist = whitelist
+        @blacklist = blacklist
         @after = urls.pop
         @before = urls.pop # May be nil
         @curl_opts = curl_opts
@@ -65,7 +67,7 @@ class SiteDiff
       def crawl(depth = nil)
         hydra = Typhoeus::Hydra.new(max_concurrency: @concurrency)
         roots.each do |tag, u|
-          Crawler.new(hydra, u, depth, @curl_opts, @debug) do |info|
+          Crawler.new(hydra, u, @whitelist, @blacklist, depth, @curl_opts, @debug) do |info|
             crawled_path(tag, info)
           end
         end


### PR DESCRIPTION
Implementing Redmine item #15168 - support for whitelists and black lists. Tested using an enhanced version of the sitediff-qa-server.