### PR TITLE
Dev interval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ AllCops:
 Style/MutableConstant:
   Exclude:
     - 'lib/sitediff/sanitize/dom_transform.rb'
+
+Style/GuardClause:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 209
+  Max: 213
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:
@@ -53,7 +53,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 20
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 36
+  Max: 37
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 222
+  Max: 236
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 70.92
+  Max: 72.87
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 194
+  Max: 199
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:
@@ -58,7 +58,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-  Max: 6
+  Max: 7
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 72.87
+  Max: 74.03
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 199
+  Max: 209
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:
@@ -53,7 +53,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 20
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 34
+  Max: 36
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ To get help on the options for a particular command, eg: ```diff```:
 
      - There's a command line option `--concurrency=N` for both `sitediff init` and `sitediff diff` which controls the maximum number of simultaneous connections made. Lower N mean less aggressive. The default is 3.
      - The underlying curl library has [many options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html) such as `max_recv_speed_large` which can be helpful.
-
+     - There is a special command line option `--interval=T` for both `sitediff init` and `sitediff diff`. This option only works when concurrency is set to 1, and allows the fetcher to delay for T milliseconds between fetching pages.
+ 
 * **Timeouts**
 
   By default, no timeout is set but one can be added `--curl_options=timeout:60` or in your configuration file.

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -122,7 +122,7 @@ class SiteDiff
     # so passing this instead but @config.after['curl_opts'] is ignored.
     config_curl_opts = @config.before['curl_opts']
     curl_opts = config_curl_opts.clone.merge(curl_opts) if config_curl_opts
-    fetcher = Fetch.new(@cache, @config.paths, @concurrency, curl_opts, debug,
+    fetcher = Fetch.new(@cache, @config.paths, @interval, @concurrency, curl_opts, debug,
                         before: before, after: after)
     fetcher.run(&method(:process_results))
 

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -54,11 +54,11 @@ class SiteDiff
     @config.after['url']
   end
 
-  def initialize(config, cache, concurrency, verbose = true, debug = false)
+  def initialize(config, cache, concurrency, interval, verbose = true, debug = false)
     @cache = cache
     @verbose = verbose
     @debug = debug
-
+    @interval = interval
     # Check for single-site mode
     validate_opts = {}
     if !config.before['url'] && @cache.tag?(:before)

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -65,10 +65,11 @@ class SiteDiff
       Marshal.dump([tag, path.encode('UTF-8')])
     end
 
-    def get_dir(directory)        
-      #Create the dir. Must go before cache initialization!
+    def get_dir(directory)
+      # Create the dir. Must go before cache initialization!
       @dir = Pathname.new(directory || '.')
       @dir.mkpath unless @dir.directory?
       @dir.to_s
+    end
   end
 end

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -12,6 +12,7 @@ class SiteDiff
       @create = opts[:create]
       @read_tags = Set.new
       @write_tags = Set.new
+      @dir = opts[:dir] || '.'
     end
 
     # Is a tag cached?
@@ -63,5 +64,11 @@ class SiteDiff
       # Ensure encoding stays the same!
       Marshal.dump([tag, path.encode('UTF-8')])
     end
+
+    def get_dir(directory)        
+      #Create the dir. Must go before cache initialization!
+      @dir = Pathname.new(directory || '.')
+      @dir.mkpath unless @dir.directory?
+      @dir.to_s
   end
 end

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -8,10 +8,10 @@ class SiteDiff
     attr_accessor :read_tags, :write_tags
 
     def initialize(opts = {})
-      @dir = opts[:dir] || '.'
       @create = opts[:create]
       @read_tags = Set.new
       @write_tags = Set.new
+      @dir = opts[:dir] || .
     end
 
     # Is a tag cached?

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -8,10 +8,10 @@ class SiteDiff
     attr_accessor :read_tags, :write_tags
 
     def initialize(opts = {})
+      @dir = opts[:dir] || '.'
       @create = opts[:create]
       @read_tags = Set.new
       @write_tags = Set.new
-      @dir = opts[:dir] || .
     end
 
     # Is a tag cached?

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -262,7 +262,7 @@ class SiteDiff
           exit(2)
         end
       end
-      
+
       def create_regexp(string_param)
         begin
           @return_value = string_param == '' ? nil : Regexp.new(string_param)

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -213,7 +213,6 @@ class SiteDiff
     desc 'store [CONFIGFILES]',
          'Cache the current contents of a site for later comparison'
     def store(*config_files)
-
       @dir = SiteDiff.Cache.get_dir(options['directory'])
       config = SiteDiff::Config.new(config_files, @dir)
       config.validate(need_before: false)
@@ -222,7 +221,7 @@ class SiteDiff
       cache.write_tags << :before
 
       base = options[:url] || config.after['url']
-      fetcher = SiteDiff::Fetch.new(cache, 
+      fetcher = SiteDiff::Fetch.new(cache,
                                     config.paths,
                                     options['concurrency'],
                                     get_curl_opts(options),

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -84,11 +84,7 @@ class SiteDiff
     desc 'diff [OPTIONS] [CONFIGFILES]', 'Perform systematic diff on given URLs'
     def diff(*config_files)
       @interval = options['interval']
-      if @interval != 0 && options[:concurrency] != 1
-        @interval = 0
-        SiteDiff.log "--concurrency must be set to 1 in order to enable the interval feature"
-        exit (2)
-      end
+      check_interval(@interval)
       config = SiteDiff::Config.new(config_files, options[:directory])
 
       # override config based on options
@@ -180,14 +176,10 @@ class SiteDiff
     def init(*urls)
       unless (1..2).cover? urls.size
         SiteDiff.log 'sitediff init requires one or two URLs', :error
-        exit 2
+        exit(2)
       end
       @interval = options['interval']
-      if @interval != 0 && options[:concurrency] != 1
-        @interval = 0
-        SiteDiff.log "--concurrency must be set to 1 in order to enable the interval feature"
-        exit (2)
-      end
+      check_interval(@interval)
 
       curl_opts = get_curl_opts(options)
 
@@ -247,6 +239,13 @@ class SiteDiff
           curl_opts[:ssl_verifyhost] = 0
         end
         curl_opts
+      end
+
+      def check_interval(interval)
+        if interval != 0 && options[:concurrency] != 1
+          SiteDiff.log '--concurrency must be set to 1 in order to enable the interval feature'
+          exit(2)
+        end
       end
     end
   end

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -214,11 +214,12 @@ class SiteDiff
       config = SiteDiff::Config.new(config_files, options['directory'])
       config.validate(need_before: false)
 
-      cache = SiteDiff::Cache.new(create: true)
+      cache = SiteDiff::Cache.new(dir: config.directory, create: true)
       cache.write_tags << :before
 
       base = options[:url] || config.after['url']
-      fetcher = SiteDiff::Fetch.new(cache, config.paths,
+      fetcher = SiteDiff::Fetch.new(cache, 
+                                    config.paths,
                                     options['concurrency'],
                                     get_curl_opts(options),
                                     options[:debug],

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -27,6 +27,10 @@ class SiteDiff
                  type: :boolean,
                  default: false,
                  desc: 'Debug mode. Stop on certain errors and produce a traceback.'
+    class_option :interval,
+                 type: :numeric,
+                 default: 0,
+                 desc: 'Crawling delay - interval in milliseconds'
 
     # Thor, by default, exits with 0 no matter what!
     def self.exit_on_failure?
@@ -109,7 +113,7 @@ class SiteDiff
       cache.read_tags << :after if %w[after all].include?(options['cached'])
       cache.write_tags << :before << :after
 
-      sitediff = SiteDiff.new(config, cache, options[:concurrency],
+      sitediff = SiteDiff.new(config, cache, options[:concurrency], options['interval'],
                               options['verbose'], options[:debug])
       num_failing = sitediff.run(get_curl_opts(options), options[:debug])
       exit_code = num_failing > 0 ? 2 : 0
@@ -176,6 +180,7 @@ class SiteDiff
       curl_opts = get_curl_opts(options)
 
       creator = SiteDiff::Config::Creator.new(options[:concurrency],
+                                              options['interval'],
                                               curl_opts,
                                               options[:debug],
                                               *urls)

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -83,6 +83,12 @@ class SiteDiff
            desc: 'Max number of concurrent connections made'
     desc 'diff [OPTIONS] [CONFIGFILES]', 'Perform systematic diff on given URLs'
     def diff(*config_files)
+      @interval = options['interval']
+      if @interval != 0 && options[:concurrency] != 1
+        @interval = 0
+        SiteDiff.log "--concurrency must be set to 1 in order to enable the interval feature"
+        exit (2)
+      end
       config = SiteDiff::Config.new(config_files, options[:directory])
 
       # override config based on options
@@ -113,7 +119,7 @@ class SiteDiff
       cache.read_tags << :after if %w[after all].include?(options['cached'])
       cache.write_tags << :before << :after
 
-      sitediff = SiteDiff.new(config, cache, options[:concurrency], options['interval'],
+      sitediff = SiteDiff.new(config, cache, options[:concurrency], @interval,
                               options['verbose'], options[:debug])
       num_failing = sitediff.run(get_curl_opts(options), options[:debug])
       exit_code = num_failing > 0 ? 2 : 0
@@ -175,6 +181,12 @@ class SiteDiff
       unless (1..2).cover? urls.size
         SiteDiff.log 'sitediff init requires one or two URLs', :error
         exit 2
+      end
+      @interval = options['interval']
+      if @interval != 0 && options[:concurrency] != 1
+        @interval = 0
+        SiteDiff.log "--concurrency must be set to 1 in order to enable the interval feature"
+        exit (2)
       end
 
       curl_opts = get_curl_opts(options)

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -32,7 +32,7 @@ class SiteDiff
       def create(opts, &block)
         @config = {}
         @callback = block
-        @dir = opts[:dir])
+        @dir = opts[:dir]
 
         # Handle other options
         @depth = opts[:depth]

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -33,17 +33,17 @@ class SiteDiff
         @config = {}
         @callback = block
 
-        # Handle options
-        @dir = Pathname.new(opts[:directory])
+        #Create the dir. Must go before cache initialization!
+        @directory = Pathname.new(opts[:directory] || '.')
+        @directory.mkpath unless @directory.directory?
+
+        # Handle other options
         @depth = opts[:depth]
         @rules = Rules.new(@config, opts[:rules_disabled]) if opts[:rules]
 
-        # Create the dir. Must go before cache initialization!
-        @dir.mkpath unless @dir.directory?
-
         # Setup instance vars
         @paths = Hash.new { |h, k| h[k] = Set.new }
-        @cache = Cache.new(dir: @dir.to_s, create: true)
+        @cache = Cache.new(dir: @directory.to_s, create: true)
         @cache.write_tags << :before << :after
 
         build_config

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -11,8 +11,9 @@ require 'yaml'
 class SiteDiff
   class Config
     class Creator
-      def initialize(concurrency, curl_opts, debug, *urls)
+      def initialize(concurrency, interval, curl_opts, debug, *urls)
         @concurrency = concurrency
+        @interval = interval
         @after = urls.pop
         @before = urls.pop # May be nil
         @curl_opts = curl_opts
@@ -65,7 +66,7 @@ class SiteDiff
       def crawl(depth = nil)
         hydra = Typhoeus::Hydra.new(max_concurrency: @concurrency)
         roots.each do |tag, u|
-          Crawler.new(hydra, u, depth, @curl_opts, @debug) do |info|
+          Crawler.new(hydra, u, @interval, depth, @curl_opts, @debug) do |info|
             crawled_path(tag, info)
           end
         end

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -32,11 +32,7 @@ class SiteDiff
       def create(opts, &block)
         @config = {}
         @callback = block
-
-        #Create the dir. Must go before cache initialization!
-        @directory = Pathname.new(opts[:directory] || '.')
-        @directory.mkpath unless @directory.directory?
-        @dir = @directory.to_s
+        @dir = opts[:dir])
 
         # Handle other options
         @depth = opts[:depth]

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -36,6 +36,7 @@ class SiteDiff
         #Create the dir. Must go before cache initialization!
         @directory = Pathname.new(opts[:directory] || '.')
         @directory.mkpath unless @directory.directory?
+        @dir = @directory.to_s
 
         # Handle other options
         @depth = opts[:depth]
@@ -43,7 +44,7 @@ class SiteDiff
 
         # Setup instance vars
         @paths = Hash.new { |h, k| h[k] = Set.new }
-        @cache = Cache.new(dir: @directory.to_s, create: true)
+        @cache = Cache.new(dir: @dir, create: true)
         @cache.write_tags << :before << :after
 
         build_config
@@ -113,6 +114,10 @@ class SiteDiff
             cache.db.db
           GITIGNORE
         end
+      end
+
+      def directory
+        @dir
       end
 
       def config_file

--- a/lib/sitediff/crawler.rb
+++ b/lib/sitediff/crawler.rb
@@ -41,7 +41,7 @@ class SiteDiff
       # Insert delay to limit fetching rate
       if @interval != 0
         SiteDiff.log("Waiting #{@interval} milliseconds.", :info)
-        sleep(@interval / 1000)
+        sleep(@interval / 1000.0)
       end
 
       wrapper = UriWrapper.new(@base + rel, @curl_opts, @debug)

--- a/lib/sitediff/crawler.rb
+++ b/lib/sitediff/crawler.rb
@@ -38,12 +38,6 @@ class SiteDiff
 
       @found << rel
 
-      # Insert delay to limit fetching rate
-      if @interval != 0
-        SiteDiff.log("Waiting #{@interval} milliseconds.", :info)
-        sleep(@interval / 1000.0)
-      end
-
       wrapper = UriWrapper.new(@base + rel, @curl_opts, @debug)
       wrapper.queue(@hydra) do |res|
         fetched_uri(rel, depth, res)
@@ -70,6 +64,11 @@ class SiteDiff
         read_result: res,
         document: doc
       )
+      # Insert delay to limit fetching rate
+      if @interval != 0
+        SiteDiff.log("Waiting #{@interval} milliseconds.", :info)
+        sleep(@interval / 1000.0)
+      end
       @callback[info]
 
       return unless depth >= 1
@@ -85,7 +84,6 @@ class SiteDiff
       # Queue them in turn
       rels.each do |r|
         next if @found.include? r
-
         add_uri(r, depth - 1)
       end
     end

--- a/lib/sitediff/crawler.rb
+++ b/lib/sitediff/crawler.rb
@@ -84,6 +84,7 @@ class SiteDiff
       # Queue them in turn
       rels.each do |r|
         next if @found.include? r
+
         add_uri(r, depth - 1)
       end
     end

--- a/lib/sitediff/crawler.rb
+++ b/lib/sitediff/crawler.rb
@@ -15,6 +15,7 @@ class SiteDiff
 
     # Create a crawler with a base URL
     def initialize(hydra, base,
+                   interval,
                    depth = DEFAULT_DEPTH,
                    curl_opts = UriWrapper::DEFAULT_CURL_OPTS,
                    debug = true,
@@ -22,6 +23,7 @@ class SiteDiff
       @hydra = hydra
       @base_uri = Addressable::URI.parse(base)
       @base = base
+      @interval = interval
       @found = Set.new
       @callback = block
       @curl_opts = curl_opts
@@ -35,6 +37,12 @@ class SiteDiff
       return if @found.include? rel
 
       @found << rel
+
+      # Insert delay to limit fetching rate
+      if @interval != 0
+        SiteDiff.log("Waiting #{@interval} milliseconds.", :info)
+        sleep(@interval / 1000)
+      end
 
       wrapper = UriWrapper.new(@base + rel, @curl_opts, @debug)
       wrapper.queue(@hydra) do |res|

--- a/lib/sitediff/fetch.rb
+++ b/lib/sitediff/fetch.rb
@@ -62,6 +62,7 @@ class SiteDiff
     # Process fetch results
     def process_results(path, results)
       return unless results.size == @tags.size
+
       @callback[path, results]
     end
   end

--- a/lib/sitediff/fetch.rb
+++ b/lib/sitediff/fetch.rb
@@ -45,6 +45,8 @@ class SiteDiff
         else
           uri = UriWrapper.new(base + path, @curl_opts, @debug)
           uri.queue(@hydra) do |resl|
+            SiteDiff.log "Fetched URI { #uri }", :info
+            sleep ( 0.5 )
             @cache.set(tag, path, resl)
             results[tag] = resl
             process_results(path, results)


### PR DESCRIPTION
Fixing RM item #17013. 
Adding an --interval parameter to insert a delay between fetching pages.
Requires suppressing concurrency by setting --concurrency=1