### PR TITLE
Better config errors; refs #18019

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,14 +11,6 @@ Lint/IneffectiveAccessModifier:
   Exclude:
     - 'lib/sitediff/config.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: Whitelist.
-# Whitelist: present?, blank?, presence, try, try!
-Lint/SafeNavigationConsistency:
-  Exclude:
-    - 'lib/sitediff/sanitize.rb'
-
 # Offense count: 2
 # Configuration parameters: ContextCreatingMethods, MethodCreatingMethods.
 Lint/UselessAccessModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,20 +52,6 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'Thorfile'
-    - 'lib/sitediff.rb'
-    - 'lib/sitediff/cache.rb'
-    - 'lib/sitediff/cli.rb'
-    - 'lib/sitediff/config.rb'
-    - 'lib/sitediff/config/creator.rb'
-    - 'lib/sitediff/crawler.rb'
-    - 'lib/sitediff/diff.rb'
-    - 'lib/sitediff/fetch.rb'
-    - 'lib/sitediff/result.rb'
-    - 'lib/sitediff/sanitize.rb'
-    - 'lib/sitediff/sanitize/regexp.rb'
-    - 'lib/sitediff/uriwrapper.rb'
-    - 'lib/sitediff/webserver.rb'
-    - 'lib/sitediff/webserver/resultserver.rb'
 
 # Offense count: 3
 # Configuration parameters: MinBodyLength.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,11 +12,6 @@ Lint/IneffectiveAccessModifier:
     - 'lib/sitediff/config.rb'
 
 # Offense count: 1
-Lint/NestedMethodDefinition:
-  Exclude:
-    - 'lib/sitediff/config/creator.rb'
-
-# Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: Whitelist.
 # Whitelist: present?, blank?, presence, try, try!

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 74.03
+  Max: 78.75
 
 # Offense count: 6
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -30,7 +30,7 @@ Metrics/BlockLength:
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:
-  Max: 11
+  Max: 13
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.
@@ -39,7 +39,7 @@ Metrics/ParameterLists:
 
 # Offense count: 5
 Metrics/PerceivedComplexity:
-  Max: 11
+  Max: 13
 
 # Offense count: 1
 Security/MarshalLoad:

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -9,6 +9,7 @@ require 'rainbow'
 require 'rubygems'
 require 'yaml'
 
+# SiteDiff Object.
 class SiteDiff
   # SiteDiff installation directory.
   ROOT_DIR = File.dirname(File.dirname(__FILE__))

--- a/lib/sitediff/cache.rb
+++ b/lib/sitediff/cache.rb
@@ -4,6 +4,7 @@ require 'set'
 require 'fileutils'
 
 class SiteDiff
+  # SiteDiff Cache Handler.
   class Cache
     attr_accessor :read_tags, :write_tags
 

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -32,6 +32,11 @@ class SiteDiff
                  type: :numeric,
                  default: 0,
                  desc: 'Crawling delay - interval in milliseconds'
+    class_option 'verbose',
+                 type: :boolean,
+                 aliases: '-v',
+                 default: false,
+                 desc: 'Show verbose output in terminal'
 
     # Thor, by default, exits with 0 no matter what!
     def self.exit_on_failure?
@@ -85,11 +90,6 @@ class SiteDiff
            enum: %w[none all before after],
            default: 'before',
            desc: 'Use the cached version of these sites, if available.'
-    option 'verbose',
-           type: :boolean,
-           aliases: '-v',
-           default: false,
-           desc: 'Show differences between versions for each page in terminal'
     option :concurrency,
            type: :numeric,
            default: 3,
@@ -138,7 +138,10 @@ class SiteDiff
                     options['after-report'])
     rescue Config::InvalidConfig => e
       SiteDiff.log "Invalid configuration: #{e.message}", :error
-      SiteDiff.log "at #{e.backtrace}", :error
+      SiteDiff.log e.backtrace, :error if options[:verbose]
+    rescue Config::ConfigNotFound => e
+      SiteDiff.log "Invalid configuration: #{e.message}", :error
+      SiteDiff.log e.backtrace, :error if options[:verbose]
     else # no exception was raised
       # Thor::Error  --> exit(1), guaranteed by exit_on_failure?
       # Failing diff --> exit(2), populated above
@@ -170,7 +173,7 @@ class SiteDiff
       ).wait
     rescue SiteDiffException => e
       SiteDiff.log e.message, :error
-      SiteDiff.log e.backtrace, :error
+      SiteDiff.log e.backtrace, :error if options[:verbose]
     end
 
     option :depth,
@@ -290,7 +293,7 @@ class SiteDiff
           @return_value = nil
           SiteDiff.log 'whitelist and blacklist parameters must be valid regular expressions', :error
           SiteDiff.log e.message, :error
-          SiteDiff.log e.backtrace, :error
+          SiteDiff.log e.backtrace, :error if options[:verbose]
         end
         return @return_value
       end

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -9,6 +9,7 @@ require 'sitediff/fetch'
 require 'sitediff/webserver/resultserver'
 
 class SiteDiff
+  # SiteDiff CLI.
   class Cli < Thor
     class_option 'directory',
                  type: :string,

--- a/lib/sitediff/config.rb
+++ b/lib/sitediff/config.rb
@@ -6,6 +6,7 @@ require 'pathname'
 require 'yaml'
 
 class SiteDiff
+  # SiteDiff Configuration.
   class Config
     DEFAULT_FILENAME = 'sitediff.yaml'
 

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -72,13 +72,13 @@ class SiteDiff
         hydra.run
       end
 
-      # Deduplicate paths with slashes at the end
+      # Canonicalize a path.
+      # TODO: Remove "_tag" if it is not required.
       def canonicalize(_tag, path)
-        def altered_paths(path)
-          yield path + '/'
-          yield path.sub(%r{/$}, '')
-        end
-
+        # Ignore trailing slashes.
+        path = path.chomp('/')
+        # If the path is empty after removing the trailing slash, it implies
+        # that we're on the front page, so we restore the "/".
         path.empty? ? '/' : path
       end
 

--- a/lib/sitediff/config/creator.rb
+++ b/lib/sitediff/config/creator.rb
@@ -10,6 +10,7 @@ require 'yaml'
 
 class SiteDiff
   class Config
+    # SiteDiff Config Creator Object.
     class Creator
       def initialize(concurrency, interval, whitelist, blacklist, curl_opts, debug, *urls)
         @concurrency = concurrency

--- a/lib/sitediff/crawler.rb
+++ b/lib/sitediff/crawler.rb
@@ -8,6 +8,7 @@ require 'ostruct'
 require 'set'
 
 class SiteDiff
+  # SiteDiff Crawler.
   class Crawler
     class Info < OpenStruct; end
 

--- a/lib/sitediff/diff.rb
+++ b/lib/sitediff/diff.rb
@@ -7,6 +7,7 @@ require 'rainbow'
 require 'digest'
 
 class SiteDiff
+  # SiteDiff Diff Object.
   module Diff
     module_function
 

--- a/lib/sitediff/fetch.rb
+++ b/lib/sitediff/fetch.rb
@@ -4,6 +4,7 @@ require 'sitediff/uriwrapper'
 require 'typhoeus'
 
 class SiteDiff
+  # SiteDiff Data Fetcher.
   class Fetch
     # Cache is a cache object, see sitediff/cache
     # Paths is a list of sub-paths

--- a/lib/sitediff/result.rb
+++ b/lib/sitediff/result.rb
@@ -6,6 +6,7 @@ require 'digest/sha1'
 require 'fileutils'
 
 class SiteDiff
+  # SiteDiff Result Object.
   class Result < Struct.new(:path, :before, :after, :before_encoding, :after_encoding, :error, :verbose)
     STATUS_SUCCESS  = 0   # Identical before and after
     STATUS_FAILURE  = 1   # Different before and after

--- a/lib/sitediff/sanitize.rb
+++ b/lib/sitediff/sanitize.rb
@@ -56,13 +56,13 @@ class SiteDiff
     def canonicalize_rule(name)
       (rules = @config[name]) || (return nil)
 
-      if rules[0]&.respond_to?(:[]) && rules[0]['value']
-        # Already an array
+      # Already an array? Do nothing.
+      if rules[0]&.respond_to?('each') && rules[0]&.fetch('value')
+      # If it is a hash, put it in an array.
       elsif rules['value']
-        # Hash, put it in an array
         rules = [rules]
+      # If it is a scalar value, put it in an array.
       else
-        # Scalar, put it in a hash
         rules = [{ 'value' => rules }]
       end
 

--- a/lib/sitediff/sanitize.rb
+++ b/lib/sitediff/sanitize.rb
@@ -8,6 +8,7 @@ require 'nokogiri'
 require 'set'
 
 class SiteDiff
+  # SiteDiff Sanitizer.
   class Sanitizer
     class InvalidSanitization < SiteDiffException; end
 

--- a/lib/sitediff/sanitize/regexp.rb
+++ b/lib/sitediff/sanitize/regexp.rb
@@ -2,6 +2,7 @@
 
 class SiteDiff
   class Sanitizer
+    # Regular Expression Object.
     class Regexp
       def initialize(rule)
         @rule = rule
@@ -23,6 +24,7 @@ class SiteDiff
         rule['selector'] ? WithSelector.new(rule) : new(rule)
       end
 
+      # RegExp with selector.
       class WithSelector < Regexp
         def selector?
           true

--- a/lib/sitediff/uriwrapper.rb
+++ b/lib/sitediff/uriwrapper.rb
@@ -7,6 +7,7 @@ require 'addressable/uri'
 class SiteDiff
   class SiteDiffReadFailure < SiteDiffException; end
 
+  # SiteDiff URI Wrapper.
   class UriWrapper
     DEFAULT_CURL_OPTS = {
       connecttimeout: 3,     # Don't hang on servers that don't exist

--- a/lib/sitediff/webserver.rb
+++ b/lib/sitediff/webserver.rb
@@ -3,8 +3,9 @@
 require 'webrick'
 
 class SiteDiff
+  # SiteDiff Web Server.
   class Webserver
-    # Simple webserver for testing purposes
+    # Simple web server for testing purposes.
     DEFAULT_PORT = 13_080
 
     attr_accessor :ports
@@ -63,6 +64,7 @@ class SiteDiff
 
     public
 
+    # SiteDiff Fixture Server.
     class FixtureServer < Webserver
       PORT = DEFAULT_PORT + 1
       BASE = 'spec/fixtures/ruby-doc.org'

--- a/lib/sitediff/webserver/resultserver.rb
+++ b/lib/sitediff/webserver/resultserver.rb
@@ -6,6 +6,7 @@ require 'erb'
 
 class SiteDiff
   class Webserver
+    # SiteDiff Result Server.
     class ResultServer < Webserver
       # Display a page from the cache
       class CacheServlet < WEBrick::HTTPServlet::AbstractServlet


### PR DESCRIPTION
* Show error backtraces only in verbose mode
* Make `verbose` option available for all SiteDiff methods
* Fix certain rubocop errors about top-level documentation
* Supress certain rubocop errors temporarily
  * Metrics/CyclomaticComplexity:
  * Metrics/PerceivedComplexity:
  * Metrics/AbcSize