### PR TITLE
refs #19313: Remove re-run button from report page.

### DIFF
--- a/lib/sitediff/files/report.html.erb
+++ b/lib/sitediff/files/report.html.erb
@@ -78,10 +78,6 @@
 
             </form>
           </div>
-
-          <div class="toolbar__right">
-            <a href="../run/diff" class="button button-diff">Recalculate diffs</a>
-          </div>
         </div>
       </div>
 

--- a/lib/sitediff/webserver/resultserver.rb
+++ b/lib/sitediff/webserver/resultserver.rb
@@ -68,39 +68,6 @@ class SiteDiff
       end
 
       ##
-      # Run sitediff command from browser. Probably dangerous in general.
-      class RunServlet < WEBrick::HTTPServlet::AbstractServlet
-        ##
-        # Creates a Run Servlet.
-        def initialize(_server, dir)
-          @dir = dir
-        end
-
-        ##
-        # Performs a GET request.
-        def do_GET(req, res)
-          path = req.path_info
-          if path != '/diff'
-            res['content-type'] = 'text/plain'
-            res.body = 'ERROR: Only /run/diff is supported at the moment.'
-            return
-          end
-          # Thor assumes only one command is called and some values like
-          # `options` are share across all SiteDiff::Cli instances so
-          # we can't just call SiteDiff::Cli.new().diff
-          # This is likely to go very wrong depending on how `sitediff serve`
-          # was actually called
-          cmd = "#{$PROGRAM_NAME} diff -C #{@dir} --cached=all"
-          system(cmd)
-
-          # Could also add a message to indicate success/failure
-          # But for the moment, all our files are static
-          res.set_redirect(WEBrick::HTTPStatus::Found,
-                           "/files/#{Report::REPORT_FILE_HTML}")
-        end
-      end
-
-      ##
       # Creates a Result Server.
       def initialize(port, dir, opts = {})
         unless File.exist?(File.join(dir, Report::SETTINGS_FILE))
@@ -132,7 +99,6 @@ class SiteDiff
         srv.mount('/files', WEBrick::HTTPServlet::FileHandler, dir, true)
         srv.mount('/cache', CacheServlet, @cache)
         srv.mount('/sidebyside', SideBySideServlet, @cache, @settings)
-        srv.mount('/run', RunServlet, dir)
         srv
       end
 


### PR DESCRIPTION
  To keep things simple, the user can rerun SiteDiff from the CLI instead.