### PR TITLE
refs #20803: Add ignore-whitespace option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 # Common configuration.
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Naming/MethodName:
   EnforcedStyle: snake_case
@@ -32,11 +32,11 @@ Metrics/AbcSize:
 
 # Allow developers to write complex code.
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 16
 
 # Allow developers to write complex code.
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 16
 
 # Classes can have as many lines as they want.
 # Complex classes can have many methods after all.
@@ -60,7 +60,7 @@ Metrics/BlockLength:
 
 # Some files have very long lines and need to be ignored.
 # Otherwise, we enforce a max-length of 80 characters per line.
-Metrics/LineLength:
+Layout/LineLength:
   AllowHeredoc: true
   AllowURI: true
   IgnoredPatterns:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.3
+  - 2.4
 
 sudo: false
 addons:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 SiteDiff makes it easy to see how a website changes. It can compare two similar
 sites or it can show how a single site changed over time. It helps identify
 undesirable changes to the site's HTML and it's a useful tool for conducting QA
-on re-deployments, site upgrades, and more! 
+on re-deployments, site upgrades, and more!
 
 When you run SiteDiff, it produces an HTML report showing whether pages on
 your site have changed or not. For pages that have changed, you can see a
@@ -56,14 +56,14 @@ pages have changed and not changed.
 ![page report preview](misc/sitediff%20-%20overview%20report.png?raw=true)
 
 When you click on a changed page, you see a colorized diff of the page's markup
-showing exactly what changed on the page. 
+showing exactly what changed on the page.
 ![page report preview](misc/sitediff%20-%20page%20report.png?raw=true)
 
 ## Usage
 
 Here are some instructions on getting started with SiteDiff. To see a list of
 commands that SiteDiff offers, you can run:
-                                                             
+
 ```sitediff help```
 
 To get help for a particular command, say, `diff`, you can run:
@@ -269,12 +269,12 @@ A few options are also available to control how aggressively SiteDiff crawls.
 
   - The underlying curl library has [many options](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html)
     such as `max_recv_speed_large` which can be helpful.
- 
+
   - There is a special command line option `--interval=T` for `sitediff init`.
     This option and allows the fetcher to delay for T milliseconds between
     fetching pages. You can specify this in the `sitediff.yaml` file under the
     `settings` key.
- 
+
 ### Timeouts
 
 By default, no timeout is set but one can be added `--curl_options=timeout:60`
@@ -333,25 +333,25 @@ Alternatively, it can crawl the entire site and detect all paths.
   * Running `sitediff init` also runs the `sitediff crawl` by default which
     crawls your website and puts a list of all detected paths in a `paths.txt`
     file.
-    
+
   * Running `sitediff crawl` makes sitediff crawl your site and detect
     available paths. These paths are written to a `paths.txt` file which you
     can modify according to your needs.
-    
+
   * You can also compute diffs only for paths specified in a custom paths file
     using the `--paths-file` parameter. This file should contain paths starting
     with a `/`, having one path per line.
-    
+
     ```
     sitediff diff --paths-file=/path/to/paths.txt
     ```
-    
+
   * You can also compute diffs for a handful of specific paths by specifying
     them directly on the command line using the `--paths` parameter. Each path
     should be separated by a space.
-    
+
     ```
-    sitediff diff --paths=/home /about /contact 
+    sitediff diff --paths=/home /about /contact
     ```
 
 ### selector
@@ -409,6 +409,19 @@ sanitization:
 
 Sanitization rules may also have a **path** attribute, whose value is a
 regular expression. If present, the rule will only apply to matching paths.
+
+### ignore_whitespace
+Ignore whitespace when doing the diff. This passes the `-w` option to the native OS `diff` command.
+
+```yaml
+ignore_whitespace: true
+```
+
+On the command line, use `-w` or `--ignore-whitespace`.
+
+```bash
+sitediff diff -w
+```
 
 ### dom_transform
 

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -92,7 +92,7 @@ class SiteDiff
     end
     config.validate(validate_opts)
     # Configure diff.
-    Diff::diff_config(config)
+    Diff.diff_config(config)
     @config = config
   end
 

--- a/lib/sitediff.rb
+++ b/lib/sitediff.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'sitediff/config'
+require 'sitediff/diff'
 require 'sitediff/fetch'
 require 'sitediff/result'
 require 'sitediff/report'
@@ -90,6 +91,8 @@ class SiteDiff
       validate_opts[:need_before] = false
     end
     config.validate(validate_opts)
+    # Configure diff.
+    Diff::diff_config(config)
     @config = config
   end
 

--- a/lib/sitediff/cli.rb
+++ b/lib/sitediff/cli.rb
@@ -92,6 +92,11 @@ class SiteDiff
            enum: %w[none all before after],
            default: 'before',
            desc: 'Use the cached version of these sites, if available.'
+    option 'ignore-whitespace',
+           type: :boolean,
+           default: false,
+           aliases: '-w',
+           desc: 'Ignore changes in whitespace.'
     desc 'diff [OPTIONS] [CONFIG-FILE]',
          'Compute diffs on configured URLs.'
     ##
@@ -105,6 +110,9 @@ class SiteDiff
         SiteDiff.log "Can't specify both --paths-file and --paths.", :error
         exit(-1)
       end
+
+      # Ignore whitespace option.
+      config.ignore_whitespace = options['ignore-whitespace'] if options['ignore-whitespace']
 
       # Apply "paths" override, if any.
       config.paths = options['paths'] if options['paths']

--- a/lib/sitediff/config.rb
+++ b/lib/sitediff/config.rb
@@ -41,6 +41,7 @@ class SiteDiff
       after
       before_url
       after_url
+      ignore_whitespace
     ]
 
     ##
@@ -256,6 +257,16 @@ class SiteDiff
       raise 'Paths must be an Array' unless paths.is_a? Array
 
       @config['paths'] = Config.normalize_paths(paths)
+    end
+
+    # Get ignore_whitespace option
+    def ignore_whitespace
+      @config['ignore_whitespace']
+    end
+
+    # Set ignore_whitespace option
+    def ignore_whitespace=(ignore_whitespace)
+      @config['ignore_whitespace'] = ignore_whitespace
     end
 
     ##

--- a/lib/sitediff/diff.rb
+++ b/lib/sitediff/diff.rb
@@ -68,5 +68,16 @@ class SiteDiff
       erb_path = File.join(SiteDiff::FILES_DIR, 'diff.html.erb')
       ERB.new(File.read(erb_path)).result(binding)
     end
+
+    ##
+    # Set configuration for Diffy.
+    def diff_config(config)
+      diff_options = Diffy::Diff.default_options[:diff]
+      diff_options = [diff_options] if not diff_options.kind_of?(Array)
+      # ignore_whitespace option
+      diff_options.push("-w").uniq if config.ignore_whitespace
+      Diffy::Diff.default_options[:diff] = diff_options
+    end
+
   end
 end

--- a/lib/sitediff/diff.rb
+++ b/lib/sitediff/diff.rb
@@ -73,11 +73,10 @@ class SiteDiff
     # Set configuration for Diffy.
     def diff_config(config)
       diff_options = Diffy::Diff.default_options[:diff]
-      diff_options = [diff_options] if not diff_options.kind_of?(Array)
+      diff_options = [diff_options] unless diff_options.is_a?(Array)
       # ignore_whitespace option
-      diff_options.push("-w").uniq if config.ignore_whitespace
+      diff_options.push('-w').uniq if config.ignore_whitespace
       Diffy::Diff.default_options[:diff] = diff_options
     end
-
   end
 end

--- a/lib/sitediff/sanitize.rb
+++ b/lib/sitediff/sanitize.rb
@@ -14,7 +14,7 @@ class SiteDiff
 
     TOOLS = {
       array: %w[dom_transform sanitization],
-      scalar: %w[selector remove_spacing]
+      scalar: %w[selector remove_spacing ignore_whitespace]
     }.freeze
     DOM_TRANSFORMS = Set.new(%w[remove unwrap_root unwrap remove_class])
 

--- a/sitediff.gemspec
+++ b/sitediff.gemspec
@@ -37,5 +37,5 @@ DESC
 
   # Diffy and addressable have a max version for Ruby 1.9.
   s.add_dependency 'addressable', '~> 2.5.2'
-  s.add_dependency 'diffy', '~> 3.2.0'
+  s.add_dependency 'diffy', '~> 3.3.0'
 end

--- a/sitediff.gemspec
+++ b/sitediff.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name        = 'sitediff'
   s.version     = '1.0.0'
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
   s.summary     = 'Compare two versions of a site with ease!'
   s.description = <<DESC
   SiteDiff makes it easy to see differences between two versions of a website. It accepts a set of paths to compare two versions of the site together with potential normalization/sanitization rules. From the provided paths and configuration SiteDiff generates an HTML report of all the status of HTML comparison between the given paths together with a readable diff-like HTML for each specified path containing the differences between the two versions of the site. It is useful tool for QAing re-deployments, site upgrades, etc.


### PR DESCRIPTION
- command line option: `--ignore-whitespace` or `-w`
- YAML key: `ignore_whitespace: true`
- passes "-w" option to diff command
- had to avoid just simply adding the key to the Diffy call——had to merge diff
  parameters, otherwise empty output resulted from the diff