### PR TITLE
Fix basic auth derived from URL syntax

### DIFF
--- a/lib/sitediff/uriwrapper.rb
+++ b/lib/sitediff/uriwrapper.rb
@@ -117,7 +117,7 @@ class SiteDiff
     def typhoeus_request
       params = @curl_opts.dup
       # Allow basic auth
-      params[:userpwd] = "#{@uri.user}: #{@uri.password}" if @uri.user
+      params[:userpwd] = "#{@uri.user}:#{@uri.password}" if @uri.user
 
       req = Typhoeus::Request.new(to_s, params)
 


### PR DESCRIPTION
See [RFC 7617](https://www.rfc-editor.org/rfc/rfc7617#page-3:~:text=2.%20%20constructs%20the%20user%2Dpass%20by%20concatenating%20the%20user%2Did%2C%20a%20single%0A%20%20%20%20%20%20%20colon%20(%22%3A%22)%20character%2C%20and%20the%20password%2C) The space present in construction here is invalid. It might work on some servers, but not all, and appears to be an error.