### PR TITLE
fix: Update bundler in Gemfile.lock, fix deprecated spell_checker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,4 +80,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   2.1.4
+   2.3.26


### PR DESCRIPTION
When running `bundle install` the following error appears

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated.
Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

According to https://github.com/rubygems/rubygems/issues/5234 this happens with a Bundler version below 2.3.3. The version currently defined in `Gemfile.lock` is

```
BUNDLED WITH
   2.1.4
```

This change updates the used bundler verision to 2.3.6, which at the the of writing is the version used in the docker image `docker.io/library/ruby:3.1`.