### PR TITLE
ci: Add basic GitHub Action for Ruby

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          #bundler-cache: true
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: bundle install
+      - name: Run sitediff version
+        run: ./bin/sitediff version


### PR DESCRIPTION
This change adds a basic GitHub Action workflow based on the documentation https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby