### PR TITLE
Fix Github action to build and push Docker image.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,57 +1,48 @@
-name: Build and Push Docker Image to Docker Hub
+name: Build and push to DockerHub
 
 on:
   push:
-    branches: [ "master" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-deploy:
     runs-on: ubuntu-latest
-
+    if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} .
+      - name: "Check out"
+        uses: actions/checkout@v4
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Test the Docker image
-        run: docker run --rm -d ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-    needs: build
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
 
-  # push_to_registry:
-  #   name: Push Docker image to Docker Hub
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - name: Check out the repo
-  #       uses: actions/checkout@v3
+      - name: "Login to Docker Hub"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
+      - name: "Extract metadata for Docker"
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
 
-  #     - name: Log in to Docker Hub
-  #       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: "Test Docker image"
+        run: |
+          docker run --rm -d ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-  #     - name: Extract metadata for Docker
-  #       id: meta
-  #       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-  #     - name: Build and push Docker image
-  #       uses: docker/build-push-action@v2
-  #       with:
-  #         context: "{{defaultContext}}"
-  #         push: true
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         labels: ${{ steps.meta.outputs.labels }}
+      - name: "Build and push"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR is to revise Github Action to build and push Docker image. 
This Github Action is triggered only on new tag which follows semantic version number, ie. `v1.2.9`. 
It will create a new Docker image `evolvingweb/sitediff` and push this image to Docker hub.